### PR TITLE
Add option for NextFlowItems to forward step to parent without ending current flow

### DIFF
--- a/RxFlow/Coordinator.swift
+++ b/RxFlow/Coordinator.swift
@@ -126,6 +126,13 @@ class FlowCoordinator: HasDisposeBag {
                         parentFlowCoordinator.steps.onNext(stepContextForParentFlow)
                     }
                     return (stepContext, [NextFlowItem]())
+                case .forwardToParent(let stepToSendToParentFlow):
+                    if  let parentFlowCoordinator = self.parentFlowCoordinator {
+                        let stepContextForParentFlow = StepContext(with: stepToSendToParentFlow)
+                        stepContextForParentFlow.fromChildFlow = self.flow
+                        parentFlowCoordinator.steps.onNext(stepContextForParentFlow)
+                    }
+                    return (stepContext, [NextFlowItem]())
                 case .none:
                     return (stepContext, [NextFlowItem]())
                 }

--- a/RxFlow/NextFlowItem.swift
+++ b/RxFlow/NextFlowItem.swift
@@ -47,6 +47,8 @@ public enum NextFlowItems {
     case one (flowItem: NextFlowItem)
     /// a Flow will trigger a special NextFlowItem that represents the dismissal of this Flow
     case end (withStepForParentFlow: Step)
+    /// a Flow can't handle this step so it will pass it along to its parent
+    case forwardToParent (step: Step)
     /// no further navigation will be triggered for a Step
     case none
 }


### PR DESCRIPTION

## Description
Add option for NextFlowItems to forward step to parent without ending current flow.
This is needed in the case where the parent flow have spawned multiple childFlows and is responsible for the navigation between the child flows. For example the parent flow can be an `UITabBarController` with one child flow for each tab. This is useful in the case of deep linking where outside events should trigger navigation in the app. 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] this PR is based on develop or a 'develop related' branch
- [ ] the commits inside this PR have explicit commit messages
- [ ] the Jazzy documentation has been generated (if needed -> Jazzy RxFlow)
